### PR TITLE
Update concept.html (fix Ruby code)

### DIFF
--- a/ja/concept.html
+++ b/ja/concept.html
@@ -73,7 +73,7 @@
           <textarea class="ruby-code">xs = [1,2,3,2,4]
 
 pairs = []
-(1..xs.length).each do |i|
+(0..xs.length).each do |i|
   (i+1..xs.length).each do |j|
     if xs[i] == xs[j]
       pairs.push(xs[i])


### PR DESCRIPTION
Ruby のサンプル・コードの開始インデックスが `1` だと，
`xs = [2, 2, 3, 4, 5]` のような場合に `2` を検出できません．
開始インデックスを `0` にすると解決します．